### PR TITLE
Add support for QMTech ZYJZGW core and extension board

### DIFF
--- a/blinky-qmtech-zyjzgw.xdc
+++ b/blinky-qmtech-zyjzgw.xdc
@@ -1,0 +1,16 @@
+set_property LOC F22 [get_ports clk]
+set_property IOSTANDARD LVCMOS33 [get_ports {clk}]
+
+##### Daughter board LEDs #####
+
+# LED3_FPGA BANK14_E25
+set_property LOC E25 [get_ports led]
+set_property IOSTANDARD LVCMOS33 [get_ports {led}]
+
+# LED4_FPGA BANK16_C14
+# set_property LOC C14 [get_ports led]
+# set_property IOSTANDARD LVCMOS33 [get_ports {led}]
+
+# LED5_FPGA BANK16_B14
+# set_property LOC B14 [get_ports led]
+# set_property IOSTANDARD LVCMOS33 [get_ports {led}]

--- a/makeit.sh
+++ b/makeit.sh
@@ -6,10 +6,12 @@ DB_DIR=$PREFIX/nextpnr/prjxray-db
 CHIPDB_DIR=$PREFIX/nextpnr/xilinx-chipdb
 # QMTech XC7K32T board
 BOARD=qmtech
+# QMTech XC7K325T ZYJZGW with core and expansion board
+# BOARD=qmtech-zyjzgw
 # Digilent Genesys2 board
 # BOARD=genesys2
 
-if [[ "$BOARD" == "qmtech" ]]
+if [[ "$BOARD" == "qmtech" || "$BOARD" == "qmtech-zyjzgw" ]]
 then
     PART=xc7k325tffg676-1
 elif [[ "$BOARD" == "genesys2" ]]


### PR DESCRIPTION
There's a different variant of the QMTech Kintex core board that comes with an expansion board. I bought mine from [this listing](https://www.aliexpress.com/item/1005003352927999.html?spm=a2g0o.store_pc_groupList.8148356.4.47884091h3qyEg).

Schematics and other documentation are available in [this repository](https://github.com/ChinaQMTECH/ZYJZGW_Kintex-7_XC7K325T_Starter_Kit)

The user LEDs have been left unpopulated so the blinky has to use the expansion board LEDs instead. There are slight schematic differences between the original QMTech kintex core board and the ZYJZGW variant so that they would need separate constraint files anyway.