### PR TITLE
Bash doesn't like sourcing a filename with a tilde in it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PROJECT_NAME = blinky
-PREFIX ?= ~/opt
+PREFIX ?= ${HOME}/opt
 DB_DIR = ${PREFIX}/nextpnr/prjxray-db
 CHIPDB_DIR = ${PREFIX}/nextpnr/xilinx-chipdb
 XRAY_DIR ?= ${PREFIX}/prjxray


### PR DESCRIPTION
Fixes #15.

Before:
```
rwhitby@win11:~/Projects/kintex-chatter/xc7k325t-blinky-nextpnr$ make BOARD=qmtech
/bin/bash: ~/opt/prjxray/utils/environment.sh: No such file or directory
make: *** [Makefile:34: blinky.frames] Error 1
```

After (I temporarily removed the @ so you could see the path resolved):
```
rwhitby@win11:~/Projects/kintex-chatter/xc7k325t-blinky-nextpnr$ make BOARD=qmtech
. "/home/rwhitby/opt/prjxray/utils/environment.sh"
fasm2frames --part xc7k325tffg676-1 --db-root /home/rwhitby/opt/nextpnr/prjxray-db/kintex7 blinky.fasm > blinky.frames
xc7frames2bit --part_file /home/rwhitby/opt/nextpnr/prjxray-db/kintex7/xc7k325tffg676-1/part.yaml --part_name xc7k325tffg676-1 --frm_file blinky.frames --output_file blinky.bit
```