### PR TITLE
Simplify the build process using git submodules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
-blinky.bit
-blinky.fasm
-blinky.frames
-blinky.json
-blinky_routed.json
+*.bit
+*.fasm
+*.frames
+*.json

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "nextpnr-xilinx"]
 	path = nextpnr-xilinx
 	url = git@github.com:kintex-chatter/nextpnr-xilinx.git
+[submodule "prjxray"]
+	path = prjxray
+	url = git@github.com:kintex-chatter/prjxray.git

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,27 @@
-PROJECT_NAME = blinky
+PROJECT_NAME ?= blinky
 PREFIX ?= ${HOME}/opt
 DB_DIR = ${PREFIX}/nextpnr/prjxray-db
 CHIPDB_DIR = ${PREFIX}/nextpnr/xilinx-chipdb
 XRAY_DIR ?= ${PREFIX}/prjxray
+XRAY_UTILS_DIR = ${PWD}/prjxray/env/bin
+XRAY_TOOLS_DIR = ${XRAY_DIR}/bin
+NEXTPNR_DIR ?= ${PREFIX}/nextpnr
 SHELL = /bin/bash
 PYTHONPATH ?= ${XRAY_DIR}
+QMTECH_CABLE ?= tigard
+
+# This workaround is only required for macOS, because Apple has explicitly disabled OpenMP support in their compilers.
+ifeq ($(shell uname -s),Darwin)
+NEXTPNR_BUILD_ENV = env CC=/usr/local/opt/llvm/bin/clang CXX=/usr/local/opt/llvm/bin/clang++ LDFLAGS="-L/usr/local/opt/llvm/lib -Wl,-rpath,/usr/local/opt/llvm/lib"
+NEXTPNR_CMAKE_FLAGS = -DBUILD_GUI=0
+endif
 
 ifeq (${BOARD}, qmtech)
 PART = xc7k325tffg676-1
+PROG = openFPGALoader --cable ${QMTECH_CABLE} --board qmtechKintex7 --bitstream ${PROJECT_NAME}-${BOARD}.bit
 else ifeq (${BOARD}, genesys2)
 PART = xc7k325tffg900-2
-PROG = openFPGALoader --cable digilent --bitstream blinky.bit --ftdi-channel 1
+PROG = openFPGALoader --board genesys2 --bitstream ${PROJECT_NAME}-${BOARD}.bit
 else
 .PHONY: check
 check:
@@ -21,22 +32,48 @@ check:
 endif
 
 .PHONY: all
-all: ${PROJECT_NAME}.bit
+all: ${PROJECT_NAME}-${BOARD}.bit
 	${PROG}
 
 ${PROJECT_NAME}.json: ${PROJECT_NAME}.v
 	yosys -p "synth_xilinx -flatten -abc9 -nobram -arch xc7 -top ${PROJECT_NAME}; write_json ${PROJECT_NAME}.json" $<
 
-${PROJECT_NAME}.fasm: ${PROJECT_NAME}.json
-	nextpnr-xilinx --chipdb ${CHIPDB_DIR}/${PART}.bin --xdc ${PROJECT_NAME}-${BOARD}.xdc --json $< --write ${PROJECT_NAME}_routed.json --fasm $@ --verbose --debug
+${PROJECT_NAME}-${BOARD}.fasm: ${PROJECT_NAME}.json
+	${NEXTPNR_DIR}/bin/nextpnr-xilinx --chipdb ${CHIPDB_DIR}/${PART}.bin --xdc ${PROJECT_NAME}-${BOARD}.xdc --json $< --write ${PROJECT_NAME}-${BOARD}-routed.json --fasm $@ --verbose --debug
 
-${PROJECT_NAME}.frames: ${PROJECT_NAME}.fasm
-	@. "${XRAY_DIR}/utils/environment.sh"
-	fasm2frames --part ${PART} --db-root ${DB_DIR}/kintex7 $< > $@
+${PROJECT_NAME}-${BOARD}.frames: ${PROJECT_NAME}-${BOARD}.fasm
+	${XRAY_UTILS_DIR}/fasm2frames --part ${PART} --db-root ${DB_DIR}/kintex7 $< > $@
 
-${PROJECT_NAME}.bit: ${PROJECT_NAME}.frames
-	@. "${XRAY_DIR}/utils/environment.sh"
-	xc7frames2bit --part_file ${DB_DIR}/kintex7/${PART}/part.yaml --part_name ${PART} --frm_file $< --output_file $@
+${PROJECT_NAME}-${BOARD}.bit: ${PROJECT_NAME}-${BOARD}.frames
+	${XRAY_TOOLS_DIR}/xc7frames2bit --part_file ${DB_DIR}/kintex7/${PART}/part.yaml --part_name ${PART} --frm_file $< --output_file $@
+
+.PHONY: setup
+setup:
+ifeq (${PART},)
+	make check
+endif
+	${NEXTPNR_BUILD_ENV} cmake -S nextpnr-xilinx -B nextpnr-xilinx/build ${NEXTPNR_CMAKE_FLAGS} -DARCH=xilinx -DCMAKE_INSTALL_PREFIX=${NEXTPNR_DIR}
+	make -C nextpnr-xilinx/build -j2 all
+	make -C nextpnr-xilinx/build install
+	if [ ! -f nextpnr-xilinx/xilinx/${PART}.bba ] ; then \
+		cd nextpnr-xilinx ; \
+		python3 xilinx/python/bbaexport.py --device ${PART} --bba xilinx/${PART}.bba ; \
+	fi
+	if [ ! -f nextpnr-xilinx/xilinx/${PART}.bin ] ; then \
+		cd nextpnr-xilinx ; \
+		build/bbasm -l xilinx/${PART}.bba xilinx/${PART}.bin ; \
+	fi
+	if [ ! -f ${NEXTPNR_DIR}/xilinx-chipdb/${PART}.bin ] ; then \
+		mkdir -p ${NEXTPNR_DIR}/xilinx-chipdb ; \
+		cp nextpnr-xilinx/xilinx/${PART}.bin ${NEXTPNR_DIR}/xilinx-chipdb/ ; \
+	fi
+	if [ ! -e ${NEXTPNR_DIR}/prjxray-db ] ; then \
+		ln -s ${PWD}/nextpnr-xilinx/xilinx/external/prjxray-db ${NEXTPNR_DIR}/ ; \
+	fi
+	cmake -S prjxray -B prjxray/build -DCMAKE_INSTALL_PREFIX=${XRAY_DIR}
+	make -C prjxray/build
+	make -C prjxray/build install
+	make -C prjxray env
 
 .PHONY: clean
 clean:
@@ -44,3 +81,9 @@ clean:
 	@rm -f *.frames
 	@rm -f *.fasm
 	@rm -f *.json
+
+.PHONY: clobber
+clobber:
+	rm -rf nextpnr-xilinx/build
+	rm -rf prjxray/build
+	rm -rf prjxray/env

--- a/README.md
+++ b/README.md
@@ -21,20 +21,9 @@
 1. clone/build/install yosys from https://github.com/YosysHQ/yosys or download a release from https://github.com/YosysHQ/oss-cad-suite-build/releases
    note: test have been performed with Yosys 0.13+28 (git sha1 bf85dfee5, gcc 10.2.1-6 -fPIC -Os)
 2. git clone --recurse-submodules https://github.com/kintex-chatter/xc7k325t-blinky-nextpnr.git
-3. cd xc7k325t-blinky-nextpnr/nextpnr-xilinx
-4. mkdir build
-5. pushd build
-6. cmake -DARCH=xilinx -DCMAKE_INSTALL_PREFIX=~/opt/nextpnr ..
-7. make -j2 && make install
-8. popd
-9. python3 xilinx/python/bbaexport.py --device xc7k325tffg676-1 --bba xilinx/xc7k325tffg676-1.bba
-10. build/bbasm -l xilinx/xc7k325tffg676-1.bba xilinx/xc7k325tffg676-1.bin
-11. mkdir -p ~/opt/nextpnr/xilinx-chipdb
-12. ln -s $PWD/xilinx/external/prjxray-db ~/opt/nextpnr/
-13. cp xilinx/xc7k325tffg676-1.bin ~/opt/nextpnr/xilinx-chipdb/
-14. Set XRAY_DIR to the path where Project Xray has been cloned and built, see https://symbiflow.readthedocs.io/en/latest/prjxray/docs/db_dev_process/readme.html#quickstart-guide for details. You will need to follow steps 2-5. You may be able to skip installation of Vivado if you do not plan to run the fuzzers.
-15. Change directory to this project
-16. BOARD=qmtech make
+3. cd xc7k325t-blinky-nextpnr
+4. make BOARD=qmtech setup
+5. make BOARD=qmtech all
 
 Note: Every time you change the installation of nextpnr-xilinx you will have to regenerate the chipdb,
 because the chipdb does not seem to be compatible between different binaries of nextpnr-xilinx


### PR DESCRIPTION
With these changes, the build instructions simplify to:

git clone --recurse https://github.com/kintex-chatter/xc7k325t-blinky-nextpnr.git
cd xc7k325t-blinky-nextpnr
make BOARD=qmtech setup
make BOARD=qmtech all

It also works for BOARD=genesys2, and both boards can be built and flashed from the same directory.

I will do a separate pull request with a target to install the prerequisite distribution packages for various platforms.

Why add prjxray as a submodule? The main reason to add prjxray as a submodule is so that XRAY_UTILS_DIR can be automatically set to a default value based on this known relative location for prjxray.

There is a related discussion from 2020 at https://github.com/f4pga/prjxray/issues/1384 that resulted in an independent repo for fasm2frames: https://github.com/SymbiFlow/f4pga-xc-fasm.

@unbtorsten opened an issue for further clarification at https://github.com/SymbiFlow/f4pga-xc-fasm/issues/19